### PR TITLE
fix: precache issue with netlify.toml

### DIFF
--- a/vue.config.js
+++ b/vue.config.js
@@ -34,7 +34,7 @@ module.exports = {
     },
     workboxPluginMode: 'GenerateSW',
     workboxOptions: {
-      exclude: ['/\.map$/', '/_redirects/', '/netlify.toml'],
+      exclude: ['/\.map$/', '/_redirects/', 'netlify\.toml'],
       runtimeCaching: [
         {
           urlPattern: new RegExp('https://fonts.(?:googleapis|gstatic).com/(.*)'),

--- a/vue.config.js
+++ b/vue.config.js
@@ -1,12 +1,22 @@
 // Compress static text assets at build time
 const CompressionPlugin = require('compression-webpack-plugin')
+const VuetifyLoaderPlugin = require('vuetify-loader/lib/plugin')
 
 module.exports = {
   configureWebpack: {
     optimization: {
+      moduleIds: 'hashed',
+      runtimeChunk: 'single',
       splitChunks: {
         minSize: 10000,
-        maxSize: 250000
+        maxSize: 250000,
+        cacheGroups: {
+          vendor: {
+            test: /[\\/]node_modules[\\/]/,
+            name: 'vendors',
+            chunks: 'all'
+          }
+        }
       }
     }
   },
@@ -24,7 +34,7 @@ module.exports = {
     },
     workboxPluginMode: 'GenerateSW',
     workboxOptions: {
-      exclude: [/\.map$/, /_redirects/],
+      exclude: ['/\.map$/', '/_redirects/', '/netlify.toml'],
       runtimeCaching: [
         {
           urlPattern: new RegExp('https://fonts.(?:googleapis|gstatic).com/(.*)'),
@@ -57,6 +67,8 @@ module.exports = {
 
     // enable build time compression
     config.plugin('CompressionPlugin').use(CompressionPlugin)
+    // VuetifyLoaderPlugin
+    config.plugin('VuetifyLoaderPlugin').use(VuetifyLoaderPlugin)
   },
 
   productionSourceMap: false


### PR DESCRIPTION
Browser console reports this error when the app is deployed on Netlify:

Uncaught (in promise) bad-precaching-response: bad-precaching-response :: [{"url":"https://ui.ambianic.ai/netlify.toml?__WB_REVISION__=e0e4d44af049b1ac6c84cc9a8566723d","status":404}]
    at l.o (https://storage.googleapis.com/workbox-cdn/releases/4.3.1/workbox-precaching.prod.js:1:1749)
    at async Promise.all (index 0)
    at async l.install (https://storage.googleapis.com/workbox-cdn/releases/4.3.1/workbox-precaching.prod.js:1:1221)