### PR TITLE
fix: made visibility icon responsive to small resolutions

### DIFF
--- a/cypress/integration/ambianic-tests/remote-connection.spec.js
+++ b/cypress/integration/ambianic-tests/remote-connection.spec.js
@@ -17,10 +17,15 @@ context('RemoteConnections', () => {
     //     cy.get('#peerID').contains('5568ec87-42d8-47b0-aeea-01a125db0623')
     // })
 
-    it('Should switch to a remote Edge Peer ID', () => {
+    it('Should retrieve and display user PeerID', () => {
         // cy.get('#btn-settings').click()
         cy.get('#remotePeerID').type('917d5f0a-6469-4d33-b5c2-efd858118b74')
         cy.get('#btn-sendRemotePeerID').click()
-        cy.get('#edgePeerID').contains('917d5f0a-6469-4d33-b5c2-efd858118b74')
+
+        // makes sure ID is hidden by default
+        cy.get('input').should('not.have.value', '917d5f0a-6469-4d33-b5c2-efd858118b74')
+        // reveal hidden PeerID
+        cy.get('#toggle-visibility').click()
+        cy.get('#peerId-container').should('have.value', '917d5f0a-6469-4d33-b5c2-efd858118b74')
     })
 })

--- a/cypress/integration/ambianic-tests/remote-connection.spec.js
+++ b/cypress/integration/ambianic-tests/remote-connection.spec.js
@@ -4,7 +4,13 @@
 
 /// <reference types="cypress" />
 
-context('RemoteConnections', () => {
+const checkViewPort = (cy, device) => {
+    cy.viewport(device)
+    cy.get('#toggle-visibility').should('be.visible')
+    cy.get('#peerId-container').should('be.visible')
+}
+
+context('RemoteConnections',    () => {
     beforeEach(() => {
       cy.visit('http://localhost:8080/settings')
     })
@@ -27,5 +33,23 @@ context('RemoteConnections', () => {
         // reveal hidden PeerID
         cy.get('#toggle-visibility').click()
         cy.get('#peerId-container').should('have.value', '917d5f0a-6469-4d33-b5c2-efd858118b74')
+    })
+
+    it('Displays elements in smaller viewports', () => {
+        cy.get('#remotePeerID').type('917d5f0a-6469-4d33-b5c2-efd858118b74')
+        cy.get('#btn-sendRemotePeerID').click()
+
+        // ensure elements are shown on smaller viewports
+        checkViewPort(cy, 'iphone-5')
+        checkViewPort(cy, 'iphone-6')
+        checkViewPort(cy, 'samsung-s10')
+        checkViewPort(cy, 'samsung-note9')
+        checkViewPort(cy, 'iphone-x')
+        checkViewPort(cy, 'iphone-xr')
+
+        checkViewPort(cy, 'ipad-mini')
+        checkViewPort(cy, 'ipad-2')
+        checkViewPort(cy, 'macbook-11')
+        checkViewPort(cy, 'macbook-13')
     })
 })

--- a/src/components/shared/ListItem.vue
+++ b/src/components/shared/ListItem.vue
@@ -2,55 +2,48 @@
 <template>
   <v-list-item :two-line="twoLine">
     <v-list-item-icon>
-      <div v-if="!sensitiveField">
-        <v-icon :color="iconColor">
-          mdi-{{ iconName }}
-        </v-icon>
-      </div>
-      <div v-else>
-        <v-icon
-          style="padding-bottom: 14px"
-          v-if="sensitive"
-          id="toggle-visibility"
-          @click="sensitive = false"
-        >
-          mdi-eye
-        </v-icon>
-        <v-icon
-          style="padding-bottom: 15px"
-          v-else
-          @click="sensitive = true"
-        >
-          mdi-eye-off-outline
-        </v-icon>
-      </div>
+      <v-icon :color="iconColor">
+        mdi-{{ iconName }}
+      </v-icon>
     </v-list-item-icon>
     <v-list-item-content v-if="sensitiveField">
       <v-row dense>
         <v-col>
-          <div class="sensitive-ctn">
-            <v-list-item-title class="headline">
-              <input
-                :value="title"
-                :placeholder="title"
-                disabled
-                style="color: #000;"
-                id="peerId-container"
-                :type="sensitive ? 'password' : 'text'"
-              >
-            </v-list-item-title>
+          <v-list-item-title class="headline">
+            <input
+              :value="title"
+              :placeholder="title"
+              disabled
+              style="color: #000;"
+              id="peerId-container"
+              :type="sensitive ? 'password' : 'text'"
+            >
+          </v-list-item-title>
 
-            <div style="display: flex; align-items: center; justify-content: center;">
-              <v-list-item-subtitle>
-                {{ subtitle }}
-              </v-list-item-subtitle>
-            </div>
+          <div style="display: flex; align-items: center; justify-content: center;">
+            <v-list-item-subtitle>
+              {{ subtitle }}
+            </v-list-item-subtitle>
           </div>
         </v-col>
 
-        <!--        <v-col>-->
-        <!--        -->
-        <!--        </v-col>-->
+        <v-col>
+          <v-icon
+            style="padding-bottom: 14px"
+            v-if="sensitive"
+            id="toggle-visibility"
+            @click="sensitive = false"
+          >
+            mdi-eye
+          </v-icon>
+          <v-icon
+            style="padding-bottom: 15px"
+            v-else
+            @click="sensitive = true"
+          >
+            mdi-eye-off-outline
+          </v-icon>
+        </v-col>
       </v-row>
     </v-list-item-content>
 
@@ -117,16 +110,3 @@ export default {
   }
 }
 </script>
-
-<style lang="css" scoped >
-  .sensitive-ctn {
-    display : flex;
-    flex-direction: column;
-  }
-
-  @media (max-width: 400px) {
-    .sensitive-ctn {
-      /*width: 190px;*/
-    }
-  }
-</style>

--- a/src/components/shared/ListItem.vue
+++ b/src/components/shared/ListItem.vue
@@ -2,31 +2,16 @@
 <template>
   <v-list-item :two-line="twoLine">
     <v-list-item-icon>
-      <v-icon :color="iconColor">
-        mdi-{{ iconName }}
-      </v-icon>
-    </v-list-item-icon>
-    <v-list-item-content v-if="sensitiveField">
-      <div style="display : flex; justify-content: space-between">
-        <div style="display : flex; flex-direction: column">
-          <v-list-item-title class="headline">
-            <input
-              :value="title"
-              disabled
-              :type="sensitive ? 'password' : 'text'"
-            >
-          </v-list-item-title>
-
-          <div style="display: flex; align-items: center; justify-content: center;">
-            <v-list-item-subtitle>
-              {{ subtitle }}
-            </v-list-item-subtitle>
-          </div>
-        </div>
-
+      <div v-if="!sensitiveField">
+        <v-icon :color="iconColor">
+          mdi-{{ iconName }}
+        </v-icon>
+      </div>
+      <div v-else>
         <v-icon
-          style="padding-bottom: 15px"
+          style="padding-bottom: 14px"
           v-if="sensitive"
+          id="toggle-visibility"
           @click="sensitive = false"
         >
           mdi-eye
@@ -39,9 +24,37 @@
           mdi-eye-off-outline
         </v-icon>
       </div>
+    </v-list-item-icon>
+    <v-list-item-content v-if="sensitiveField">
+      <v-row dense>
+        <v-col>
+          <div class="sensitive-ctn">
+            <v-list-item-title class="headline">
+              <input
+                :value="title"
+                :placeholder="title"
+                disabled
+                style="color: #000;"
+                id="peerId-container"
+                :type="sensitive ? 'password' : 'text'"
+              >
+            </v-list-item-title>
+
+            <div style="display: flex; align-items: center; justify-content: center;">
+              <v-list-item-subtitle>
+                {{ subtitle }}
+              </v-list-item-subtitle>
+            </div>
+          </div>
+        </v-col>
+
+        <!--        <v-col>-->
+        <!--        -->
+        <!--        </v-col>-->
+      </v-row>
     </v-list-item-content>
 
-    <v-list-item-content v-else >
+    <v-list-item-content v-else>
       <v-list-item-title class="headline">
         {{ title }}
       </v-list-item-title>
@@ -90,6 +103,13 @@ export default {
       default: null
     }
   },
+  methods: {
+    divideIdValue (id) {
+      const arr = id.split('')
+      arr.splice(0, arr.length / 2)
+      return arr.join('')
+    }
+  },
   data () {
     return {
       sensitive: true
@@ -97,3 +117,16 @@ export default {
   }
 }
 </script>
+
+<style lang="css" scoped >
+  .sensitive-ctn {
+    display : flex;
+    flex-direction: column;
+  }
+
+  @media (max-width: 400px) {
+    .sensitive-ctn {
+      /*width: 190px;*/
+    }
+  }
+</style>

--- a/src/components/shared/ListItem.vue
+++ b/src/components/shared/ListItem.vue
@@ -96,13 +96,6 @@ export default {
       default: null
     }
   },
-  methods: {
-    divideIdValue (id) {
-      const arr = id.split('')
-      arr.splice(0, arr.length / 2)
-      return arr.join('')
-    }
-  },
   data () {
     return {
       sensitive: true

--- a/src/views/Onboarding.vue
+++ b/src/views/Onboarding.vue
@@ -694,7 +694,7 @@ export default {
         navigator.share({
           title: 'Ambianic Edge Device Access Request',
           text:
-            'Hi Blob, please send me an access invitation to your Ambianic Edge Device'
+              'Hi Blob, please send me an access invitation to your Ambianic Edge Device'
         })
       } else {
         this.sendRequestDialog = state

--- a/src/views/Onboarding.vue
+++ b/src/views/Onboarding.vue
@@ -270,8 +270,7 @@
 
                     <div class="message-container">
                       <v-card-text class="step-text">
-                        Hi Blob, please send me an access invitation to your
-                        Ambianic Edge Device.
+                        {{ invitationMessage }}
                         <br>
                       </v-card-text>
                     </div>
@@ -620,6 +619,7 @@ export default {
       stepLevel: localStorage.getItem('lastOnboardingStage') || 1,
       stepContentName: localStorage.getItem('lastOnboardingStep') || '',
       isInstallingApp: false,
+      invitationMessage: 'Hi ____, please send me an access invitation to your Ambianic Edge Device.',
       appInstallationComplete: false,
       completedSteps: [],
       sendRequestDialog: false,
@@ -693,8 +693,7 @@ export default {
       if (navigator.share) {
         navigator.share({
           title: 'Ambianic Edge Device Access Request',
-          text:
-              'Hi Blob, please send me an access invitation to your Ambianic Edge Device'
+          text: this.invitationMessage
         })
       } else {
         this.sendRequestDialog = state


### PR DESCRIPTION
This resolves: #513 

This PR contains fixes made to make the `peerID Visibility Icon` responsive to smaller resolutions.
The applied solution is to make proper use of `media queries` for the input container and also divide the PeerID's length by 2 when hidden. This ensures it doesn't overflow the appropriate space.

**Note:** The `peerID` length is only divided when hidden. The full value is revealed when visible. 

See attached screenshots:

![media-queries](https://user-images.githubusercontent.com/29664439/106947847-3bd4f980-672b-11eb-8ede-0f7cf31e024b.png)



