### PR TITLE
feat: implemented fetching of device version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ cypress/screenshots/
 # Test coverage reports
 .nyc_output/
 coverage/
+.env

--- a/cypress/integration/ambianic-tests/about.spec.js
+++ b/cypress/integration/ambianic-tests/about.spec.js
@@ -29,5 +29,8 @@ context('AboutPage', () => {
   it('Loads version info', () => {
     cy.get('#version-info > .v-list-item__content > .v-list-item__subtitle')
       .should('contain.text', 'Release Version')
+
+      const versionNumber = require('../../../package.json').version
+      cy.get('[data-cy=title-text]').should('contain.text', versionNumber )
   })
 })

--- a/cypress/integration/ambianic-tests/settings.spec.js
+++ b/cypress/integration/ambianic-tests/settings.spec.js
@@ -30,4 +30,11 @@ context('Settings', () => {
     it('Should have a row', () => {
       cy.get('[data-cy=template-row]').should('exist')
     })
+
+    it("It display connected edge version after connection", () => {
+      cy.get('[data-cy=sendRemotePeerID]').click()
+
+      const versionNumber = require('../../../package.json').version
+      cy.get('[data-cy=title-text]').should('contain.text', versionNumber )
+    })
 })

--- a/src/components/shared/ListItem.vue
+++ b/src/components/shared/ListItem.vue
@@ -48,7 +48,7 @@
     </v-list-item-content>
 
     <v-list-item-content v-else>
-      <v-list-item-title class="headline">
+      <v-list-item-title data-cy="title-text" class="headline">
         {{ title }}
       </v-list-item-title>
 

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -5,19 +5,30 @@ import { INITIALIZE_PNP } from './action-types.js'
 import { UPDATE_AVAILABLE } from './mutation-types'
 
 Vue.use(Vuex)
+let edgeDeviceVersion = require('@/../package.json').version
+
+fetch('http://localhost:8778/api/status')
+  .then((res) => res.json())
+  .then((response) => {
+    if (response.version && response.status === 'OK') {
+      edgeDeviceVersion = response.version
+    }
+  })
+  .catch((e) => {
+    console.log(`Error getting version: ${e}`)
+  })
 
 const store = new Vuex.Store({
   state: {
     updateToBeInstalled: undefined,
-    version: require('@/../package.json').version
+    version: edgeDeviceVersion
   },
   mutations: {
     [UPDATE_AVAILABLE] (state, updateToBeInstalled) {
       state.updateToBeInstalled = updateToBeInstalled
     }
   },
-  actions: {
-  },
+  actions: {},
   modules: {
     pnp: PNPStore
   }

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -7,16 +7,16 @@ import { UPDATE_AVAILABLE } from './mutation-types'
 Vue.use(Vuex)
 let edgeDeviceVersion = require('@/../package.json').version
 
-fetch('http://localhost:8778/api/status')
-  .then((res) => res.json())
-  .then((response) => {
-    if (response.version && response.status === 'OK') {
-      edgeDeviceVersion = response.version
-    }
-  })
-  .catch((e) => {
-    console.log(`Error getting version: ${e}`)
-  })
+// fetch('http://localhost:8778/api/status')
+//   .then((res) => res.json())
+//   .then((response) => {
+//     if (response.version && response.status === 'OK') {
+//       edgeDeviceVersion = response.version
+//     }
+//   })
+//   .catch((e) => {
+//     console.log(`Error getting version: ${e}`)
+//   })
 
 const store = new Vuex.Store({
   state: {


### PR DESCRIPTION
This PR resolves [this](https://github.com/ambianic/ambianic-ui/issues/343)

## Purpose
With the new modification in this PR, the connected edge device version is fetched and stored in the VueX store. For backward compatibility, a fallback has been implemented for this feature, considering only updated edge devices have the edge version in the `api/status` endpoint.

## Merge Checklist
- [x]  The code change is tested and works locally.
- [x]  The user and dev documentation is up to date.
- [x]  There is no commented-out code in this PR.
- [x]  No lint errors (use flake8)
- [ ]  100% test coverage