### PR TITLE
test: add pnp mutations tests

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -5,8 +5,10 @@ tasks:
   - init: |
       npm install
     command: |
-      echo "Starting Ambianic PWA in dev mode"
-      npm run serve
+      echo "To start Ambianic UI in dev mode:"
+      echo "npm run serve"
+      echo "To run tests:"
+      echo "npm run test"
   # - command: |
   #    echo "Waiting for npm install to finish"
   #    gp await-port 8080 && gp preview $(gp url 8080)/index.html

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "fs-vacuum": "^1.2.10",
     "istanbul-lib-coverage": "^3.0.0",
     "jest": "^26.0.1",
+    "lodash": "^4.17.21",
     "nyc": "^15.0.1",
     "sass": "^1.26.5",
     "sass-loader": "^10.0.4",

--- a/src/store/pnp.js
+++ b/src/store/pnp.js
@@ -69,7 +69,7 @@ const state = {
   /**
     Connection to the remote Ambianic Edge device
   */
-  peerConnection: null,
+  peerConnection: undefined,
   /**
     Status of current peer connection to remote peer
   */
@@ -81,14 +81,14 @@ const state = {
   /**
     PeerFetch instance
   */
-  peerFetch: PeerFetch
+  peerFetch: undefined
 }
 
 const mutations = {
   [PEER_DISCONNECTED] (state) {
-    state.peerConnection = null
+    state.peerConnection = undefined
     state.peerConnectionStatus = PEER_DISCONNECTED
-    state.peerFetch = null
+    state.peerFetch = undefined
   },
   [PEER_DISCOVERED] (state) {
     state.peerConnectionStatus = PEER_DISCOVERED
@@ -132,7 +132,7 @@ const mutations = {
   },
   [REMOTE_PEER_ID_REMOVED] (state) {
     console.log('Removing remote Peer Id from local storage')
-    state.remotePeerId = null
+    state.remotePeerId = undefined
     window.localStorage.removeItem(`${STORAGE_KEY}.remotePeerId`)
   },
   [PEER_FETCH] (state, peerFetch) {

--- a/tests/unit/store/pnp-mutations.spec.js
+++ b/tests/unit/store/pnp-mutations.spec.js
@@ -1,0 +1,152 @@
+import Vue from 'vue'
+import { mount, createLocalVue } from '@vue/test-utils'
+import Vuetify from 'vuetify'
+import Vuex from 'vuex'
+import VueRouter from 'vue-router'
+import { cloneDeep } from 'lodash'
+import pnp from '@/store/pnp.js'
+import {
+  PEER_DISCONNECTED,
+  PEER_CONNECTING,
+  PEER_DISCOVERING,
+  PEER_DISCOVERED,
+  PEER_AUTHENTICATING,
+  PEER_CONNECTED,
+  PEER_CONNECTION_ERROR,
+  PNP_SERVICE_DISCONNECTED,
+  PNP_SERVICE_CONNECTING,
+  PNP_SERVICE_CONNECTED,
+  USER_MESSAGE,
+  NEW_PEER_ID,
+  NEW_REMOTE_PEER_ID,
+  REMOTE_PEER_ID_REMOVED,
+  PEER_FETCH
+} from '@/store/mutation-types.js'
+import {
+  INITIALIZE_PNP,
+  PNP_SERVICE_CONNECT,
+  PNP_SERVICE_RECONNECT,
+  PEER_DISCOVER,
+  PEER_CONNECT,
+  PEER_AUTHENTICATE,
+  REMOVE_REMOTE_PEER_ID,
+  CHANGE_REMOTE_PEER_ID,
+  HANDLE_PEER_CONNECTION_ERROR
+} from '@/store/action-types.js'
+
+describe('PnP state machine tests - p2p communication layer', () => {
+// global
+  
+  // localVue is used for tests instead of the production Vue instance
+  let localVue
+
+  // the Vuex store we will be testing against
+  let store
+
+  beforeEach(() => {
+    localVue = createLocalVue()
+    localVue.use(Vuex)    
+    store = new Vuex.Store({ modules: { pnp: cloneDeep(pnp) } })
+    // console.debug("store:", store )
+    const state = store.state
+    // console.debug("store.state:", { state } )
+  })
+
+  afterEach(() => {
+  })
+  
+  // test mutations
+
+  test('PEER_DISCONNECTED', () => {
+    expect(store.state.pnp.peerConnection).toBe(undefined)
+    expect(store.state.pnp.peerConnectionStatus).toBe(PEER_DISCONNECTED)
+    expect(store.state.pnp.peerFetch).toBe(undefined)
+    store.commit(PEER_DISCONNECTED)
+    expect(store.state.pnp.peerConnection).toBe(undefined)
+    expect(store.state.pnp.peerConnectionStatus).toBe(PEER_DISCONNECTED)
+    expect(store.state.pnp.peerFetch).toBe(undefined)
+  })
+
+  test('PEER_DISCOVERED', () => {
+    store.commit(PEER_DISCONNECTED)
+    expect(store.state.pnp.peerConnectionStatus).toBe(PEER_DISCONNECTED)
+    store.commit(PEER_DISCOVERED)
+    expect(store.state.pnp.peerConnectionStatus).toBe(PEER_DISCOVERED)
+  })
+
+  test('PEER_DISCOVERING', () => {
+    store.commit(PEER_DISCONNECTED)
+    expect(store.state.pnp.peerConnectionStatus).toBe(PEER_DISCONNECTED)
+    store.commit(PEER_DISCOVERING)
+    expect(store.state.pnp.peerConnectionStatus).toBe(PEER_DISCOVERING)
+  })
+
+  test('PEER_CONNECTING', () => {
+    store.commit(PEER_DISCONNECTED)
+    expect(store.state.pnp.peerConnectionStatus).toBe(PEER_DISCONNECTED)
+    store.commit(PEER_CONNECTING)
+    expect(store.state.pnp.peerConnectionStatus).toBe(PEER_CONNECTING)
+  })
+
+  test('PEER_AUTHENTICATING', () => {
+    store.commit(PEER_CONNECTING)
+    expect(store.state.pnp.peerConnectionStatus).toBe(PEER_CONNECTING)
+    store.commit(PEER_AUTHENTICATING)
+    expect(store.state.pnp.peerConnectionStatus).toBe(PEER_AUTHENTICATING)
+  })
+
+  test('PEER_CONNECTED', () => {
+    store.commit(PEER_CONNECTING)
+    expect(store.state.pnp.peerConnectionStatus).toBe(PEER_CONNECTING)
+    store.commit(PEER_CONNECTED, 'a peerConnection')
+    expect(store.state.pnp.peerConnectionStatus).toBe(PEER_CONNECTED)
+    expect(store.state.pnp.peerConnection).toBe('a peerConnection')
+  })
+
+  test('PEER_CONNECTION_ERROR', () => {
+    store.commit(PEER_CONNECTING)
+    expect(store.state.pnp.peerConnectionStatus).toBe(PEER_CONNECTING)
+    store.commit(PEER_CONNECTION_ERROR)
+    expect(store.state.pnp.peerConnectionStatus).toBe(PEER_CONNECTION_ERROR)
+  })
+
+  test('PNP_SERVICE_DISCONNECTED', () => {
+    store.commit(PNP_SERVICE_DISCONNECTED)
+    expect(store.state.pnp.pnpServiceConnectionStatus).toBe(PNP_SERVICE_DISCONNECTED)
+  })
+
+  test('PNP_SERVICE_CONNECTED', () => {
+    store.commit(PNP_SERVICE_CONNECTED)
+    expect(store.state.pnp.pnpServiceConnectionStatus).toBe(PNP_SERVICE_CONNECTED)
+  })
+
+  test('USER_MESSAGE', () => {
+    store.commit(USER_MESSAGE, 'a user message')
+    expect(store.state.pnp.userMessage).toBe('a user message')
+  })
+
+  test('NEW_PEER_ID', () => {
+    store.commit(NEW_PEER_ID, 'a new peer id')
+    expect(store.state.pnp.myPeerId).toBe('a new peer id')
+  })
+
+  test('NEW_REMOTE_PEER_ID', () => {
+    store.commit(NEW_REMOTE_PEER_ID, 'a new remote peer id')
+    expect(store.state.pnp.remotePeerId).toBe('a new remote peer id')
+  })
+
+  test('REMOTE_PEER_ID_REMOVED', () => {
+    store.commit(REMOTE_PEER_ID_REMOVED)
+    expect(store.state.pnp.remotePeerId).toBe(undefined)
+  })
+
+  test('PEER_FETCH', () => {
+    store.commit(PEER_FETCH, 'a peerFetch instance')
+    expect(store.state.pnp.peerFetch).toBe('a peerFetch instance')
+  })
+
+
+
+  // test actions
+
+})


### PR DESCRIPTION
## Purpose
Currently the pnp state machine has poor test coverage.

## Approach
Add pnp state machine tests using vue test utils. See docs:
https://vue-test-utils.vuejs.org/guides/using-with-vuex.html

