### PR TITLE
feat: replaced download icon with cloud icon

### DIFF
--- a/cypress/integration/ambianic-tests/navbar.spec.js
+++ b/cypress/integration/ambianic-tests/navbar.spec.js
@@ -5,8 +5,8 @@ context('Check Navbar Items', () => {
     cy.visit('http://localhost:8080/about')
   })
 
-  it('Should be a download off button before edge connection', () => {
-    cy.get('[data-cy=download-off]').should('exist')
+  it('Should display a connection-offline icon before edge connection', () => {
+    cy.get('[data-cy=connection-status]').should('exist')
   })
 
   /** future buttons

--- a/src/components/NavBar.vue
+++ b/src/components/NavBar.vue
@@ -26,13 +26,28 @@
         to="timeline"
       />
 
-      <nav-button
-        data-cy="download-off"
-        icon="download-off"
-        color="warning"
-        v-if="!isEdgeConnected"
-        to="edge-connect"
-      />
+      <div>
+        <v-tooltip bottom>
+          <template
+              v-if="!isEdgeConnected"
+              #activator="{ on, attrs }"
+          >
+            <div
+                v-bind="attrs"
+                v-on="on">
+              <nav-button
+                  data-cy="connection-status"
+                  icon="cloud-off-outline"
+                  :color="connectionIconColor"
+                  to="edge-connect"
+                  v-bind="attrs"
+                  v-on="on"
+              />
+            </div>
+          </template>
+          <span> Device Offline </span>
+        </v-tooltip>
+        </div>
 
       <!-- Future navbar icons
       <v-text-field
@@ -179,6 +194,7 @@ export default {
     on: true,
     newFavorites: 0,
     newAlerts: 2,
+    connectionIconColor: 'warning',
     logo: '../assets/logo5.svg',
     items: [
       { icon: 'history', text: 'Timeline', link: '/timeline' },

--- a/tests/unit/components/navbar.spec.js
+++ b/tests/unit/components/navbar.spec.js
@@ -75,4 +75,5 @@ describe('NavBar', () => {
     expect(nav.exists()).toBe(true)
     expect(item.length).toBe(5)
   })
+
 })


### PR DESCRIPTION
## Purpose
This pull request will fix this issue  [here](https://github.com/ambianic/ambianic-ui/issues/697). 

## Approach
New code within this pull request changes the `download-off` icon to a `cloud-off` icon to better depict the connection status of the PWA to an edge device 

#### TODOs within this pull request
- [ ] Implement color coding of the new icon
- [ ] Write sufficient unit tests based on the connection status  

## Merge Checklist
- [x]  The code change is tested and works locally.
- [x]  The user and dev documentation is up to date.
- [x]  There is no commented out code in this PR.
- [x]  No lint errors (use flake8)
- [x]  100% test coverage